### PR TITLE
Add Docker image 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git/
+design/
+node_modules/
+
+.dockerignore
+Dockerfile
+LICENSE
+README.md

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,10 +4,10 @@ name: Build Docker Image
 on:
   push:
     branches:
+      - master
       - main
-      - ci/docker-build # @FIXME: Remove this line before opening an MR
   pull_request:
-    branches: [ main ]
+    branches: [ main, master ]
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - ci/docker-build # @FIXME: Remove this line before opening an MR
   pull_request:
     branches: [ main ]
   # Allow manually triggering the workflow.

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,44 @@
+---
+name: Build Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [ main ]
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create docker tag (from git reference)
+        # A tag name may only contain lower- and uppercase letters, digits, underscores, periods and dashes.
+        run: |
+          echo "TAG=$(echo -n "${{ github.ref_name }}" \
+            | tr --complement --squeeze-repeats '[:alnum:]._-' '_')" \
+            >> "${GITHUB_ENV}"
+
+      - uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker Image
+        run: |
+          docker build \
+            --tag "ghcr.io/potherca-contrib/jsontag-rest-server:${{ env.TAG }}" \
+          .
+          docker push "ghcr.io/potherca-contrib/jsontag-rest-server:${{ env.TAG }}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Build Docker Image
         run: |
           docker build \
-            --tag "ghcr.io/potherca-contrib/jsontag-rest-server:${{ env.TAG }}" \
+            --tag "ghcr.io/poef/jsontag-rest-server:${{ env.TAG }}" \
           .
-          docker push "ghcr.io/potherca-contrib/jsontag-rest-server:${{ env.TAG }}"
+          docker push "ghcr.io/poef/jsontag-rest-server:${{ env.TAG }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# ==============================================================================
+# Dependencies
+# ------------------------------------------------------------------------------
+FROM node:18-alpine3.17 as builder
+
+WORKDIR /usr/src/app
+COPY package.json ./
+
+# @TODO: Once development is stable, `npm ci --only=production` should be used instead of `npm install`
+RUN npm install --omit=dev
+# ==============================================================================
+
+
+# ==============================================================================
+# Application
+# ------------------------------------------------------------------------------
+FROM alpine:3.17
+
+ENV NODE_ENV=production
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache nodejs=~18.14
+
+COPY --chown=node:node . /app
+COPY --chown=node:node --from=builder /usr/src/app/node_modules /app/node_modules
+
+WORKDIR /app
+
+CMD [ "node", "/app/src/main.mjs" ]
+# ==============================================================================
+
+
+# ==============================================================================
+# Metadata
+# ------------------------------------------------------------------------------
+# @TODO: Once development is stable, the following should also be added
+#    org.label-schema.build-date=${BUILD_DATE} \ # Usually $(date --iso-8601=seconds)
+#    org.label-schema.vcs-ref=${BUILD_REF} \ # Usually $(git describe --tags --always)
+#    org.label-schema.version=${VERSION} \ # Usually $(git describe --tags --abbrev=0)
+#    org.opencontainers.image.created="${BUILD_DATE}" \
+#    org.opencontainers.image.version="${VERSION}"
+LABEL maintainer="Auke van Slooten <auke@muze.nl>" \
+    org.label-schema.description="JSONTag REST Server" \
+    org.label-schema.docker.cmd='docker run --expose 3000 --interactive --name=jsontag-rest-server --rm --tty --volume "\$PWD/my-data.json:/app/data.jsontag" jsontag-rest-server' \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.name="jsontag-rest-server" \
+    org.label-schema.url="https://github.com/poef/jsontag-rest-server" \
+    org.label-schema.usage="https://github.com/poef/jsontag-rest-server" \
+    org.label-schema.vcs-url="https://github.com/poef/jsontag-rest-server" \
+    org.label-schema.vendor="Auke van Slooten" \
+    org.opencontainers.image.authors="Auke van Slooten <auke@muze.nl>" \
+    org.opencontainers.image.description="JSONTag REST Server" \
+    org.opencontainers.image.documentation="https://github.com/poef/jsontag-rest-server" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.source="https://github.com/poef/jsontag-rest-server" \
+    org.opencontainers.image.title="jsontag-rest-server" \
+    org.opencontainers.image.url="https://github.com/poef/jsontag-rest-server" \
+    org.opencontainers.image.vendor="Auke van Slooten"
+# ==============================================================================

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,85 @@
+# Docker Image
+
+A minimal Docker image is available for the `jsontag-rest-server`.
+
+The docker image can be created from the [`Dockerfile`](../Dockerfile) in the root of the repository.
+
+The image is based on [alpine][1] with [NodeJS installed][2], rather than using the official NodeJS image. This is done to keep the image size down (from more than 200MB to less than 100MB).
+
+## Installation
+
+The image can be build from the Dockerfile provide by this project.
+
+### Building the image
+
+The image can be built using the following command:
+
+```bash
+docker build --tag jsontag-rest-server .
+```
+
+## Usage
+
+To use the `jsontag-rest-server` container, two things are needed:
+
+1. **The port the server is listening on needs to be exposed.**<br>
+   This can be done by using the `--expose` flag when running the container. By default, this is port 3000. The port can be changed by setting the `NODE_PORT` environment variable (see the "Environment Variables" section). 
+
+2. **A data file needs to be mounted into the container.**<br>
+   The image comes with [a default dataset][3], loaded from `/app/data.jsontag` file that can be used to test the server. To use a different dataset, mount it into the container using the `--volume` flag when running the container.
+
+To change the default for either the port or the data file, see the "Environment Variables" section.
+
+An example of running the server (with the default data file and port):
+
+```bash
+docker run \
+    --expose 3000 \
+    --interactive \
+    --name=jsontag-rest-server \
+    --rm \
+    --tty \
+    --volume "$PWD/my-data.json:/app/data.jsontag"
+    jsontag-rest-server
+```
+
+### Docker User
+
+Similar to the official NodeJS image, the image is set up to run as a non-root user. The user and group are both `node`. The user is created with a UID of 1000 and a GID of 1000.
+
+### Environment Variables
+
+The runtime environment variables that can be set are:
+
+- `DATAFILE`:  The file that is loaded into the REST server.<br>
+  Defaults to `data.jsontag`.
+- `NODE_ENV`:  The environment the server is running in.<br>
+  Defaults to `production`.
+- `NODE_PORT`: The port the server will listen on.<br>
+  Defaults to `3000`.
+
+These variables can be set when _building_ the Docker image:
+
+```bash
+docker build --tag jsontag-rest-server\
+    --build-arg DATAFILE=my-data.jsontag \
+    --build-arg NODE_ENV=development \
+    --build-arg NODE_PORT=8080 \
+    .
+```
+
+or when _running_ the Docker container
+    
+```bash
+docker run \
+    --env DATAFILE=my-data.jsontag \
+    --env NODE_ENV=development \
+    --env NODE_PORT=8080 \
+    --expose 8080 \
+    --volume "$PWD/my-data.json:/app/my-data.jsontag"    
+    jsontag-rest-server
+```
+
+[1]: https://hub.docker.com/_/alpine
+[2]: https://pkgs.alpinelinux.org/package/edge/main/x86/nodejs
+[3]: ../data.jsontag

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -2,13 +2,27 @@
 
 A minimal Docker image is available for the `jsontag-rest-server`.
 
-The docker image can be created from the [`Dockerfile`](../Dockerfile) in the root of the repository.
+<!-- toc -->
+
+- [Installation](#installation)
+  - [Building the image](#building-the-image)
+  - [Pulling the image](#pulling-the-image)
+- [Usage](#usage)
+  - [Docker User](#docker-user)
+  - [Environment Variables](#environment-variables)
+  - [Extending the image](#extending-the-image)
+
+<!-- tocstop -->
+
+The docker image is created from the [`Dockerfile`](../Dockerfile) in the root of the repository.
 
 The image is based on [alpine][1] with [NodeJS installed][2], rather than using the official NodeJS image. This is done to keep the image size down (from more than 200MB to less than 100MB).
 
+If more functionality is needed, the image can be extended by creating a new `Dockerfile` that uses the `jsontag-rest-server` image as a base.
+
 ## Installation
 
-The image can be build from the Dockerfile provide by this project.
+The image can be build from the Dockerfile provide by this project or pulled from the GitHub Container Registry.
 
 ### Building the image
 
@@ -16,6 +30,14 @@ The image can be built using the following command:
 
 ```bash
 docker build --tag jsontag-rest-server .
+```
+
+### Pulling the image
+
+The image can be pulled from the GitHub Container Registry using the following command:
+
+```bash
+docker pull ghcr.io/poef/jsontag-rest-server
 ```
 
 ## Usage
@@ -79,6 +101,28 @@ docker run \
     --volume "$PWD/my-data.json:/app/my-data.jsontag"    
     jsontag-rest-server
 ```
+### Extending the image
+
+The image can be extended by creating a new `Dockerfile` that uses the `jsontag-rest-server` image as a base.
+
+For example, to add a custom data file to the image:
+
+```dockerfile
+FROM node:lts-buster-slim
+
+# ... (other instructions)
+
+COPY --from=ghcr.io/poef/jsontag-rest-server /app/ /usr/src/app/jsontag-rest-server/
+COPY my-data.jsontag /usr/src/app/jsontag-rest-server/data.jsontag
+
+# ... (other instructions)
+
+# The jsontag-rest-server is assumed to be started from entrypoint.sh
+CMD ["entrypoint.sh"]
+``` 
+
+
+
 
 [1]: https://hub.docker.com/_/alpine
 [2]: https://pkgs.alpinelinux.org/package/edge/main/x86/nodejs

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"@codemirror/lang-javascript": "^6.1.2",
 		"@codemirror/view": "^6.7.3",
 		"@discoveryjs/json-ext": "^0.5.7",
-		"@muze-nl/jsontag": "file:../jsontag/",
+		"@muze-nl/jsontag": "^0.6.3",
 		"@rollup/plugin-node-resolve": "^15.0.1",
 		"cm6-theme-solarized-dark": "^0.2.0",
 		"codemirror": "^6.0.1",


### PR DESCRIPTION
This MR add a `Dockerfile` (and accompanying `.dockerignore`) to allow shipping jsontag-rest-server as a docker image.

It also includes a GitHub Workflow to generate an image from `master` and push it to the GitHub Container Registry (ghcr.io).

For the image to be available from ghcr.io it is possible some setting _might_ need to be changed.
<sup>(DM me in case of question about that.)

This MR can be seen working in my repo:

- https://github.com/potherca-contrib/jsontag-rest-server/pull/1 which created https://github.com/potherca-contrib/jsontag-rest-server/pkgs/container/jsontag-rest-server 